### PR TITLE
修正了一个可能在高分辨率下导致截图模糊的问题。

### DIFF
--- a/src/com/lew/scott/screencapture/JavaScreenCaptureTool.java
+++ b/src/com/lew/scott/screencapture/JavaScreenCaptureTool.java
@@ -94,6 +94,13 @@ public class JavaScreenCaptureTool extends Frame implements MouseListener, Mouse
 	private static final int Exit_After_Copy_Code = 0x02;
 	private static final String CFG_FILE_NAME = "jsct.properties";
 
+	//禁用缩放
+	static {
+
+		System.setProperty("sun.java2d.uiScale", "1");
+
+	}
+
 	private JavaScreenCaptureTool() {
 		// 取得屏幕大小
 		GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();


### PR DESCRIPTION
在我的windows11机器上发现截图的图片dpi有所降低，这是修正之前得到的图片：
![image](https://user-images.githubusercontent.com/50037713/184425142-5e34af8d-f905-4d2a-93fd-294356c7103f.png)

这是修正之后得到的图片：
![image](https://user-images.githubusercontent.com/50037713/184425349-133f1775-80df-477e-9efc-670c89089cea.png)

我不确定是否对其它版本的windows有效，但至少在我这里得到了解决。😄